### PR TITLE
Add staging environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,11 @@ name: Build and Deploy Application
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,15 @@ jobs:
         cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
         terraform_version: 1.5.0
 
+    - name: Set Terraform Workspace
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "TF_WORKSPACE=${{ secrets.TF_WORKSPACE_STAGING }}" >> $GITHUB_ENV
+        elif [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          echo "TF_WORKSPACE=${{ secrets.TF_WORKSPACE_PROD }}" >> $GITHUB_ENV
+        fi
+      shell: bash
+
     - name: Terraform Init
       run: terraform init
       working-directory: terraform

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -2,12 +2,21 @@ name: Terraform Destroy
 
 on:
   workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select the environment (staging or prod)'
+        required: true
+        default: 'staging'
+        options:
+          - staging
+          - prod
 
 env:
   TF_API_TOKEN: "${{ secrets.TF_API_TOKEN }}"
   TF_CLOUD_ORGANIZATION: "${{ secrets.TF_CLOUD_ORGANIZATION }}"
   TF_CLOUD_HOSTNAME: "${{ secrets.TF_CLOUD_HOSTNAME }}"
-  TF_WORKSPACE: "${{ secrets.TF_WORKSPACE }}"
+  TF_WORKSPACE_STAGING: "${{ secrets.TF_WORKSPACE_STAGING }}"
+  TF_WORKSPACE_PROD: "${{ secrets.TF_WORKSPACE_PROD }}"
 
 jobs:
   destroy:
@@ -23,6 +32,15 @@ jobs:
         with:
           cli_config_credentials_token: ${{ env.TF_API_TOKEN }}
           terraform_version: 1.5.0
+
+      - name: Set Terraform Workspace
+        run: |
+          if [[ "${{ github.event.inputs.environment }}" == "staging" ]]; then
+            export TF_WORKSPACE="${{ secrets.TF_WORKSPACE_STAGING }}"
+          elif [[ "${{ github.event.inputs.environment }}" == "prod" ]]; then
+            export TF_WORKSPACE="${{ secrets.TF_WORKSPACE_PROD }}"
+          fi
+        shell: bash
 
       - name: Terraform Init
         run: terraform init

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Set Terraform Workspace
         run: |
           if [[ "${{ github.event.inputs.environment }}" == "staging" ]]; then
-            export TF_WORKSPACE="${{ secrets.TF_WORKSPACE_STAGING }}"
+            echo TF_WORKSPACE="${{ secrets.TF_WORKSPACE_STAGING }}" >> $GITHUB_ENV
           elif [[ "${{ github.event.inputs.environment }}" == "prod" ]]; then
-            export TF_WORKSPACE="${{ secrets.TF_WORKSPACE_PROD }}"
+            echo TF_WORKSPACE="${{ secrets.TF_WORKSPACE_PROD }}" >> $GITHUB_ENV
           fi
         shell: bash
 

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -14,11 +14,11 @@ data "aws_route53_zone" "web_resume_app" {
 }
 
 resource "aws_acm_certificate" "cert" {
-  count = local.has_custom_domain ? 1 : 0
+  provider = aws.us_east_1
+  count    = local.has_custom_domain ? 1 : 0
 
   domain_name       = local.app_domain_name
   validation_method = "DNS"
-  region            = "us-east-1"
 }
 
 resource "aws_route53_record" "cert_cname" {
@@ -39,10 +39,10 @@ resource "aws_route53_record" "cert_cname" {
 }
 
 resource "aws_acm_certificate_validation" "cert_validation" {
-  count = local.has_custom_domain ? 1 : 0
+  provider = aws.us_east_1
+  count    = local.has_custom_domain ? 1 : 0
 
   certificate_arn = aws_acm_certificate.cert[0].arn
-  region          = "us-east-1"
 }
 
 resource "aws_cloudfront_origin_access_identity" "web_resume_app" {

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -18,6 +18,7 @@ resource "aws_acm_certificate" "cert" {
 
   domain_name       = local.app_domain_name
   validation_method = "DNS"
+  region            = "us-east-1"
 }
 
 resource "aws_route53_record" "cert_cname" {
@@ -41,6 +42,7 @@ resource "aws_acm_certificate_validation" "cert_validation" {
   count = local.has_custom_domain ? 1 : 0
 
   certificate_arn = aws_acm_certificate.cert[0].arn
+  region          = "us-east-1"
 }
 
 resource "aws_cloudfront_origin_access_identity" "web_resume_app" {

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -5,3 +5,13 @@ provider "aws" {
     role_arn = var.deployment_role_arn
   }
 }
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "us_east_1"
+
+  assume_role {
+    role_arn = var.deployment_role_arn
+  }
+}
+

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,5 +1,5 @@
 provider "aws" {
-  region = var.default_region
+  region = var.region
 
   assume_role {
     role_arn = var.deployment_role_arn

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,4 +1,4 @@
-variable "default_region" {
+variable "region" {
   type    = string
   default = "us-east-1"
 }


### PR DESCRIPTION
This PR adds a `staging` environment, which is controlled by Terraform workspaces. The `staging` and `prod` deployments will share the same AWS account but will live in different regions.

A `staging` deployment can be triggered by opening a PR. Once the PR is merged into `main`, a `prod` deployment will be triggered.

Closes https://github.com/mDemianchuk/web-resume/issues/13